### PR TITLE
Update documentation with contributing guide and directory structure (#42)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,331 @@
+# Contributing to Video Downloader
+
+Thank you for your interest in contributing to Video Downloader! This guide will help you understand our project structure and conventions.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Project Structure](#project-structure)
+- [Code Organization](#code-organization)
+- [Testing Conventions](#testing-conventions)
+- [Import/Export Patterns](#importexport-patterns)
+- [Development Workflow](#development-workflow)
+- [Code Style](#code-style)
+- [Commit Messages](#commit-messages)
+- [Pull Requests](#pull-requests)
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/your-username/video-downloader-app.git`
+3. Install dependencies: `mise install && mise run install`
+4. Create a feature branch: `git checkout -b feat/your-feature`
+5. Make your changes
+6. Run tests: `mise run test`
+7. Submit a pull request
+
+## Project Structure
+
+For detailed directory structure, see [docs/DIRECTORY_STRUCTURE.md](docs/DIRECTORY_STRUCTURE.md).
+
+### Quick Reference
+
+```
+src/
+├── main/           # Main process (Electron)
+├── renderer/       # Renderer process (React UI)
+├── preload/        # Preload scripts
+├── shared/         # Shared code between processes
+└── test/           # Test utilities and setup
+```
+
+## Code Organization
+
+### Where to Place New Code
+
+#### Components
+- **Location**: `src/renderer/components/`
+- **Convention**: One component per file
+- **Example**: `src/renderer/components/Button.tsx`
+
+#### React Hooks
+- **Location**: `src/renderer/hooks/`
+- **Convention**: Prefix with `use`
+- **Example**: `src/renderer/hooks/useDownloadTasks.ts`
+
+#### IPC Handlers
+- **Location**: `src/main/ipc/handlers/`
+- **Convention**: Group by feature
+- **Example**: `src/main/ipc/handlers/download.handler.ts`
+
+#### Database Repositories
+- **Location**: `src/main/db/repositories/`
+- **Convention**: One repository per entity
+- **Example**: `src/main/db/repositories/task.repository.ts`
+
+#### Database Schemas
+- **Location**: `src/main/db/schema/`
+- **Convention**: One schema per table
+- **Example**: `src/main/db/schema/tasks.ts`
+
+#### Shared Types
+- **Location**: `src/shared/types/`
+- **Convention**: Group by domain
+- **Example**: `src/shared/types/download.types.ts`
+
+#### Validation Schemas
+- **Location**: `src/shared/validation.ts`
+- **Convention**: Zod schemas for IPC validation
+- **Example**: 
+  ```typescript
+  export const downloadSpecSchema = z.object({
+    url: z.string().url(),
+    outputPath: z.string()
+  });
+  ```
+
+#### Utilities
+- **Main Process**: `src/main/ipc/utils/`
+- **Renderer Process**: `src/renderer/utils/`
+- **Shared**: `src/shared/` (for cross-process utilities)
+
+## Testing Conventions
+
+### Test File Placement
+Tests should be placed in `__tests__` directories next to the source code:
+
+```
+src/main/db/
+├── repositories/
+│   ├── __tests__/
+│   │   └── task.repository.vitest.test.ts
+│   └── task.repository.ts
+```
+
+### Test File Naming
+
+#### Bun Tests (`.bun.test.ts`)
+Use for simple unit tests that don't require mocking:
+- Fast execution
+- No complex mocking needed
+- Example: `validation.bun.test.ts`
+
+```typescript
+import { describe, it, expect } from 'bun:test';
+
+describe('Validation', () => {
+  it('should validate URL', () => {
+    expect(isValidUrl('https://example.com')).toBe(true);
+  });
+});
+```
+
+#### Vitest Tests (`.vitest.test.ts`)
+Use for tests requiring mocks or Electron APIs:
+- Complex mocking scenarios
+- Electron API testing
+- Example: `handlers.vitest.test.ts`
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+
+describe('Handler', () => {
+  it('should handle IPC call', async () => {
+    const mock = vi.fn();
+    // ... test with mocks
+  });
+});
+```
+
+#### E2E Tests
+- **Location**: `/e2e` directory
+- **Naming**: `*.spec.ts`
+- **Framework**: Playwright
+- **Example**: `e2e/app.spec.ts`
+
+### Running Tests
+
+```bash
+# All tests
+mise run test
+
+# Bun tests only
+mise run test:bun
+
+# Vitest tests only
+mise run test:vitest
+
+# E2E tests
+mise run test:e2e
+
+# With coverage
+mise run test:coverage
+```
+
+## Import/Export Patterns
+
+Following the conventions established in PR #38:
+
+### Components (Default Exports)
+```typescript
+// src/renderer/components/Button.tsx
+export default function Button() {
+  return <button>Click me</button>;
+}
+
+// Usage
+import Button from '@/renderer/components/Button';
+```
+
+### Hooks & Utilities (Named Exports)
+```typescript
+// src/renderer/hooks/useTheme.ts
+export function useTheme() {
+  // ... hook implementation
+}
+
+// src/renderer/utils/format.ts
+export function formatDate(date: Date): string {
+  // ... implementation
+}
+
+// Usage
+import { useTheme } from '@/renderer/hooks/useTheme';
+import { formatDate } from '@/renderer/utils/format';
+```
+
+### Types (Type-Only Exports)
+```typescript
+// src/shared/types/download.types.ts
+export type DownloadStatus = 'pending' | 'downloading' | 'completed';
+export interface DownloadTask {
+  id: string;
+  status: DownloadStatus;
+}
+
+// Usage
+import type { DownloadTask } from '@/shared/types/download.types';
+```
+
+### Barrel Exports
+Use `index.ts` files for convenient imports:
+
+```typescript
+// src/renderer/components/index.ts
+export { default as Button } from './Button';
+export { default as Dialog } from './Dialog';
+
+// src/renderer/hooks/index.ts
+export * from './useTheme';
+export * from './useDownloadTasks';
+```
+
+## Development Workflow
+
+### 1. Before Starting
+- Check existing issues and PRs
+- Ensure your branch is up to date with `main`
+- Run `mise run check` to verify setup
+
+### 2. During Development
+- Write tests for new features
+- Update types when changing interfaces
+- Follow the code style guide
+- Keep commits atomic and descriptive
+
+### 3. Before Submitting
+- Run all checks: `mise run check`
+- Run tests: `mise run test`
+- Update documentation if needed
+- Ensure no empty directories (pre-commit hook will check)
+
+## Code Style
+
+### TypeScript
+- Use TypeScript for all new code
+- Enable strict mode
+- Define explicit return types for functions
+- Use `type` imports for type-only imports
+
+### React
+- Functional components with hooks
+- Use TypeScript interfaces for props
+- Keep components focused and small
+
+### General
+- Use ESLint: `mise run lint`
+- Format with Prettier: `mise run format`
+- Maximum line length: 100 characters
+- Use meaningful variable names
+
+## Commit Messages
+
+Follow conventional commits:
+
+```
+type(scope): description
+
+[optional body]
+
+[optional footer]
+```
+
+### Types
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation changes
+- `style`: Code style changes (formatting, etc.)
+- `refactor`: Code refactoring
+- `test`: Test changes
+- `chore`: Build process or auxiliary tool changes
+
+### Examples
+```bash
+feat(download): add pause/resume functionality
+fix(ipc): handle timeout in download handler
+docs: update contributing guide with test conventions
+chore: update dependencies
+```
+
+## Pull Requests
+
+### PR Guidelines
+
+1. **Title**: Clear and descriptive
+2. **Description**: Include:
+   - What changes were made
+   - Why they were necessary
+   - How to test them
+3. **Size**: Keep PRs focused and small
+4. **Tests**: Include tests for new features
+5. **Documentation**: Update if needed
+
+### PR Template
+```markdown
+## Summary
+Brief description of changes
+
+## Problem
+What issue does this solve?
+
+## Solution
+How does this solve it?
+
+## Testing
+How to test these changes
+
+## Checklist
+- [ ] Tests added/updated
+- [ ] Documentation updated
+- [ ] No empty directories
+- [ ] Lint and format checks pass
+```
+
+## Questions?
+
+If you have questions:
+1. Check existing issues
+2. Ask in the PR or issue
+3. Refer to [docs/](docs/) for more documentation
+
+Thank you for contributing! 🎉

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Kept minimal, only contains:
 - Dependency list
 - Electron builder configuration
 
+## Project Structure
+
+For detailed information about the project organization, see:
+- [Contributing Guide](CONTRIBUTING.md) - Development guidelines and conventions
+- [Directory Structure](docs/DIRECTORY_STRUCTURE.md) - Complete codebase organization
+
 ## Architecture
 
 - Main Process: Database, FFmpeg, download management

--- a/docs/DIRECTORY_STRUCTURE.md
+++ b/docs/DIRECTORY_STRUCTURE.md
@@ -1,0 +1,279 @@
+# Project Directory Structure
+
+This document describes the organization of the Video Downloader codebase after the cleanup in PR #39.
+
+## Overview
+
+The project follows a clear separation between Electron's main process, renderer process, and shared code.
+
+```
+video-downloader-app/
+├── .github/            # GitHub Actions workflows
+├── .husky/             # Git hooks
+├── docs/               # Documentation
+├── e2e/                # End-to-end tests
+├── scripts/            # Build and utility scripts
+├── src/                # Source code
+├── tests/              # Additional test files
+└── [config files]      # Various configuration files
+```
+
+## Source Code Structure (`/src`)
+
+### `/src/main` - Main Process (Electron Backend)
+
+The main process handles system-level operations, database access, and download management.
+
+```
+src/main/
+├── index.ts                     # Main process entry point
+├── db/                          # Database layer
+│   ├── client.ts               # SQLite client setup
+│   ├── init.ts                 # Database initialization
+│   ├── migrate.ts              # Migration runner
+│   ├── backup.ts               # Backup utilities
+│   ├── validation.ts           # DB-specific validation
+│   ├── repositories/           # Data access layer
+│   │   ├── __tests__/         # Repository tests
+│   │   ├── index.ts           # Barrel export
+│   │   ├── task.repository.ts # Download tasks
+│   │   ├── segment.repository.ts
+│   │   ├── settings.repository.ts
+│   │   ├── history.repository.ts
+│   │   ├── detection.repository.ts
+│   │   ├── statistics.repository.ts
+│   │   └── audit-log.repository.ts
+│   └── schema/                 # Database schemas (Drizzle)
+│       ├── index.ts
+│       ├── tasks.ts
+│       ├── segments.ts
+│       ├── settings.ts
+│       ├── history.ts
+│       ├── detections.ts
+│       ├── statistics.ts
+│       └── audit-logs.ts
+├── ipc/                        # Inter-Process Communication
+│   ├── index.ts               # IPC setup and registration
+│   ├── types.ts               # IPC-specific types
+│   ├── handlers/              # IPC message handlers
+│   │   ├── __tests__/
+│   │   ├── download.handler.ts
+│   │   ├── settings.handler.ts
+│   │   └── system.handler.ts
+│   └── utils/                 # IPC utilities
+│       ├── error-handler.ts  # Error handling wrapper
+│       └── performance.ts    # Rate limiting, caching
+└── security/                  # Security modules
+    ├── __tests__/
+    ├── csp.ts                # Content Security Policy
+    ├── path-validator.ts      # Path traversal prevention
+    ├── network-security.ts    # SSRF prevention
+    ├── drm-detector.ts        # DRM detection
+    └── legal-consent.ts       # Terms acceptance
+```
+
+### `/src/renderer` - Renderer Process (React UI)
+
+The renderer process contains the React application and UI components.
+
+```
+src/renderer/
+├── index.html              # HTML entry point
+├── main.tsx               # React app entry point
+├── App.tsx                # Root component
+├── components/            # React components
+│   ├── index.ts          # Barrel export
+│   ├── Button.tsx        # UI components
+│   └── Dialog.tsx
+├── hooks/                 # Custom React hooks
+│   ├── index.ts
+│   ├── useTheme.ts
+│   └── useDownloadTasks.ts
+├── styles/                # CSS/styling
+│   └── index.css
+└── utils/                 # Renderer utilities
+    ├── index.ts
+    └── format.ts         # Formatting helpers
+```
+
+### `/src/preload` - Preload Scripts
+
+Bridge between main and renderer processes with security context.
+
+```
+src/preload/
+├── index.ts              # Preload script
+└── types.d.ts           # Window API types
+```
+
+### `/src/shared` - Shared Code
+
+Code used by both main and renderer processes.
+
+```
+src/shared/
+├── constants/            # Shared constants
+│   └── channels.ts      # IPC channel names
+├── types/               # Shared TypeScript types
+│   ├── index.ts        # Barrel export
+│   ├── ipc.types.ts    # IPC message types
+│   ├── download.types.ts
+│   ├── media.types.ts
+│   ├── settings.types.ts
+│   └── error.types.ts
+├── validation.ts        # Zod validation schemas
+└── __tests__/          # Shared code tests
+    └── validation.bun.test.ts
+```
+
+### `/src/test` - Test Utilities
+
+Test setup and utilities.
+
+```
+src/test/
+├── setup.ts            # Test environment setup
+├── alias-test.bun.test.ts
+└── alias-test.vitest.test.ts
+```
+
+## Testing Structure
+
+### Test File Organization
+
+Tests are co-located with source files in `__tests__` directories:
+
+```
+feature/
+├── __tests__/
+│   ├── feature.bun.test.ts      # Bun unit tests
+│   └── feature.vitest.test.ts   # Vitest tests (with mocks)
+└── feature.ts
+```
+
+### Test Types
+
+1. **Unit Tests (`.bun.test.ts`)**
+   - Simple, fast unit tests
+   - No complex mocking required
+   - Run with: `bun test`
+
+2. **Integration Tests (`.vitest.test.ts`)**
+   - Tests requiring mocks
+   - Electron API testing
+   - Run with: `vitest`
+
+3. **E2E Tests (`/e2e/*.spec.ts`)**
+   - Full application testing
+   - Playwright-based
+   - Run with: `playwright test`
+
+## Configuration Files
+
+### Root Directory Configs
+
+```
+.
+├── bunfig.toml         # Bun configuration
+├── .mise.toml          # Tool versions and tasks
+├── package.json        # Dependencies and scripts
+├── tsconfig.json       # TypeScript configuration
+├── vitest.config.ts    # Vitest test configuration
+├── playwright.config.ts # E2E test configuration
+├── .eslintrc.json      # ESLint rules
+├── .prettierrc         # Code formatting
+└── .lintstagedrc.json  # Pre-commit hooks config
+```
+
+## Build Output Structure
+
+```
+dist/                   # Build output
+├── main/              # Compiled main process
+├── preload/           # Compiled preload scripts
+└── renderer/          # Compiled renderer process
+
+dist-electron/         # Electron distribution packages
+├── mac/
+├── win/
+└── linux/
+```
+
+## Key Principles
+
+### 1. Separation of Concerns
+- Main process: System operations, database, downloads
+- Renderer process: UI and user interactions
+- Preload: Secure bridge with minimal API surface
+
+### 2. Co-location
+- Tests next to source files
+- Related code grouped together
+- Clear module boundaries
+
+### 3. Type Safety
+- Shared types in `/src/shared/types`
+- Zod validation for IPC messages
+- Strict TypeScript configuration
+
+### 4. Security First
+- All security modules in `/src/main/security`
+- Input validation at boundaries
+- Path and network security enforced
+
+## Import Aliases
+
+The project uses TypeScript path aliases:
+
+```typescript
+// Instead of: import { something } from '../../../shared/types';
+import { something } from '@/shared/types';
+
+// Aliases:
+@/main/*     -> src/main/*
+@/renderer/* -> src/renderer/*
+@/shared/*   -> src/shared/*
+@/preload/*  -> src/preload/*
+```
+
+## Adding New Features
+
+When adding new features, follow this structure:
+
+1. **Types**: Define in `/src/shared/types/`
+2. **Validation**: Add schemas to `/src/shared/validation.ts`
+3. **Database**: Create schema in `/src/main/db/schema/`
+4. **Repository**: Add to `/src/main/db/repositories/`
+5. **IPC Handler**: Create in `/src/main/ipc/handlers/`
+6. **UI Components**: Add to `/src/renderer/components/`
+7. **Hooks**: Create in `/src/renderer/hooks/`
+8. **Tests**: Add `__tests__` directory next to source
+
+## Maintenance
+
+### Preventing Empty Directories
+A pre-commit hook (added in PR #41) prevents committing empty directories. See [EMPTY_DIRECTORIES.md](EMPTY_DIRECTORIES.md).
+
+### Code Quality
+- ESLint for linting
+- Prettier for formatting
+- TypeScript for type checking
+- Husky for git hooks
+- lint-staged for pre-commit checks
+
+## Recent Changes
+
+### PR #39 - Directory Cleanup
+- Removed 8 empty directories
+- Consolidated validation files
+- Organized test structure
+- Documented structure
+
+### PR #41 - Empty Directory Prevention
+- Added pre-commit hook
+- Automated empty directory detection
+
+### PR #38 - Import/Export Conventions
+- Standardized component exports (default)
+- Standardized hook/util exports (named)
+- Established type-only exports


### PR DESCRIPTION
## 概要
新しいディレクトリ構造に対応したコントリビューティングガイドとドキュメントを追加しました。

## 背景
PR #39でディレクトリ構造をクリーンアップした後、新しい構造を反映したドキュメントが必要でした。

## 変更内容

### 1. CONTRIBUTING.md の作成
包括的な開発ガイドラインを含む：
- プロジェクト構造の説明
- コード配置のガイドライン
- テスト規約（bun vs vitest）
- インポート/エクスポートパターン（PR #38から）
- コミットメッセージ規約
- PRガイドライン

### 2. docs/DIRECTORY_STRUCTURE.md の作成
詳細なディレクトリ構造ドキュメント：
- 完全なプロジェクト構造
- main/renderer/preload/shared の分離説明
- テスト構造と規約
- ビルド出力構造
- キー原則とインポートエイリアス
- 最近の変更履歴（PR #38, #39, #41）

### 3. README.md の更新
- Project Structure セクションを追加
- CONTRIBUTING.md へのリンク
- DIRECTORY_STRUCTURE.md へのリンク

## コード配置ガイドライン

新しいコードの配置場所を明確化：

| コードタイプ | 配置場所 |
|------------|---------|
| Components | `src/renderer/components/` |
| Hooks | `src/renderer/hooks/` |
| IPC handlers | `src/main/ipc/handlers/` |
| DB repositories | `src/main/db/repositories/` |
| Shared types | `src/shared/types/` |
| Validation | `src/shared/validation.ts` |

## テスト規約

| テストタイプ | ファイル拡張子 | 用途 |
|------------|--------------|------|
| Bun tests | `.bun.test.ts` | シンプルなユニットテスト |
| Vitest tests | `.vitest.test.ts` | モックが必要なテスト |
| E2E tests | `.spec.ts` | `/e2e` ディレクトリ |

## インポート/エクスポートパターン

PR #38 の規約を文書化：
- **Components**: デフォルトエクスポート
- **Hooks/Utils**: 名前付きエクスポート
- **Types**: type-only エクスポート

## 受け入れ基準
- [x] CONTRIBUTING.md が存在し、ディレクトリガイドラインを含む
- [x] 異なるコードタイプの配置場所の明確な例
- [x] テストファイル命名規約の文書化
- [x] インポート/エクスポートパターンの文書化
- [x] DIRECTORY_STRUCTURE.md へのリンク

Fixes #42

🤖 Generated with [Claude Code](https://claude.ai/code)